### PR TITLE
Add autosize boolean by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@ as content grows:
 
     React.renderComponent(
       <div>
-        <Textarea autosize></Textarea>
+        <Textarea></Textarea>
       </div>,
       document.body);
-
-As you can see there's `autosize` boolean property which would activate
-jquery-autosize plugin.
 
 This component relies on jQuery to be globally accessible via `window.jQuery`.

--- a/index.js
+++ b/index.js
@@ -4,9 +4,7 @@ require('jquery-autosize');
 module.exports = React.createClass({
 
   componentDidMount: function() {
-    if (this.props.autosize) {
-      window.jQuery(this.getDOMNode()).autosize();
-    }
+    window.jQuery(this.getDOMNode()).autosize();
   },
 
   componentWillUnmount: function() {
@@ -14,7 +12,7 @@ module.exports = React.createClass({
   },
 
   render: function() {
-    return this.transferPropsTo(React.DOM.textarea(null, this.props.children));
+    return this.transferPropsTo(React.DOM.textarea({autosize: true}, this.props.children));
   }
 
 });


### PR DESCRIPTION
There's not much point in using this component if autosize isn't turned
on so let's turn it on by default.
