### PR TITLE
fix: Check _ref is not null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,6 +127,10 @@ export default class TextareaAutosize extends React.Component {
       callback();
       return;
     }
+    if (!this._ref) {
+      callback();
+      return;
+    }
 
     const nodeHeight = calculateNodeHeight(
       this._ref,


### PR DESCRIPTION
Sometimes _ref is null and will raise an exception when passed into calculateNodeHeight.