### PR TITLE
fix: export Props type

### DIFF
--- a/.changeset/spotty-hornets-wait.md
+++ b/.changeset/spotty-hornets-wait.md
@@ -1,0 +1,5 @@
+---
+'react-textarea-autosize': patch
+---
+
+Exported `TextareaAutosizeProps` type for convenience.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ type Style = Omit<
   height?: number;
 };
 
-export type Props = JSX.IntrinsicElements['textarea'] & {
+export type TextareaAutosizeProps = JSX.IntrinsicElements['textarea'] & {
   maxRows?: number;
   minRows?: number;
   onHeightChange?: (height: number) => void;
@@ -21,7 +21,7 @@ export type Props = JSX.IntrinsicElements['textarea'] & {
 
 const TextareaAutosize: React.ForwardRefRenderFunction<
   HTMLTextAreaElement,
-  Props
+  TextareaAutosizeProps
 > = (
   {
     cacheMeasurements,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ type Style = Omit<
   height?: number;
 };
 
-type Props = JSX.IntrinsicElements['textarea'] & {
+export type Props = JSX.IntrinsicElements['textarea'] & {
   maxRows?: number;
   minRows?: number;
   onHeightChange?: (height: number) => void;


### PR DESCRIPTION
We wrap this component at work, and wanna provide our own props based on the abse ones. Exporting it makes it easier to access (and matches what the package on DefinitelyTyped did)

(I made this edit in GH's UI, so a bit hard to add the changeset requested by the bot)