### PR TITLE
Removed props.style.height type override

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,7 @@ import { noop } from './utils';
 type Style = Omit<
   NonNullable<JSX.IntrinsicElements['textarea']['style']>,
   'maxHeight' | 'minHeight'
-> & {
-  height?: number;
-};
+>;
 
 export type TextareaAutosizeProps = JSX.IntrinsicElements['textarea'] & {
   maxRows?: number;


### PR DESCRIPTION
Because of the error mentioned in #269 I removed the `height` type override. It seems that this prop is not used anywhere at all anyways and I don't see a reason why `height` should specifically be a `number` only and not a `string | number` as it is defined normally.