### PR TITLE
Updated ref attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Apart from these, the component accepts all props that are accepted by `<textare
 Get a ref to inner textarea:
 
 ```js
-<TextareaAutosize inputRef={(tag) => (this.textarea = tag)} />
+<TextareaAutosize ref={(tag) => (this.textarea = tag)} />
 ```
 
 And then call a focus on that ref:


### PR DESCRIPTION
Since `inputRef` support has been deprecated with version `8`, I think it's time for the `README` to reflect it.

Regards