### PR TITLE
fix: add `!important` to inline height property

### DIFF
--- a/.changeset/fuzzy-trains-sneeze.md
+++ b/.changeset/fuzzy-trains-sneeze.md
@@ -1,0 +1,5 @@
+---
+"react-textarea-autosize": minor
+---
+
+Set inline style's `height` property with the `"important"` priority.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,7 +75,7 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
 
     if (heightRef.current !== height) {
       heightRef.current = height;
-      node.style.height = `${height}px`;
+      node.style.setProperty(height, `${height}px`, 'important');
       onHeightChange(height);
     }
   };


### PR DESCRIPTION
As discussed #276, this PR tries to add !important to inline property