### PR TITLE
[IMPORTANT] fix: use string for `height` property

### DIFF
--- a/.changeset/rude-squids-tickle.md
+++ b/.changeset/rude-squids-tickle.md
@@ -1,0 +1,5 @@
+---
+"react-textarea-autosize": patch
+---
+
+Fixed a broken call to `setProperty` that has prevented the library to work correctly.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,7 +75,7 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
 
     if (heightRef.current !== height) {
       heightRef.current = height;
-      node.style.setProperty(height, `${height}px`, 'important');
+      node.style.setProperty("height", `${height}px`, 'important');
       onHeightChange(height);
     }
   };


### PR DESCRIPTION
This PR fixes release 8.1.0