### PR TITLE
Check if hiddenTextarea is in current body

### DIFF
--- a/src/calculateNodeHeight.ts
+++ b/src/calculateNodeHeight.ts
@@ -33,7 +33,7 @@ export default function calculateNodeHeight(
     forceHiddenStyles(hiddenTextarea);
   }
 
-  if (hiddenTextarea.parentNode === null) {
+  if (!document.body.contains(hiddenTextarea)) {
     document.body.appendChild(hiddenTextarea);
   }
 


### PR DESCRIPTION
In situations where the `document.body` was replaced, the check if `hiddenTextarea.parentNode === null` would return `false` even if in fact the _new_ `document.body` had no current `hiddenTextarea`, thus requiring a new one to be appended. The new logic checks if `!document.body.contains(hiddenTextarea)`, which should account for the _current_ `document.body`.

An alternative solution would be to check if `hiddenTextarea.isConnected`, which is probably more performant. Unfortunately, this property is not present in IE.

Yet another solution which _might_ be more performant at the expense of being more verbose, is to recursively check if `hiddenTextarea.parentNode === null` to confirm that it's in fact still in the _current_ DOM tree.

Fixes #247