### PR TITLE
fix(types): make properties optional

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ type Style = Omit<
 export type TextareaHeightChangeMeta = {
   rowHeight: number;
 };
-export type TextareaAutosizeProps = Omit<TextareaProps, 'style'> & {
+export type TextareaAutosizeProps = Partial<Omit<TextareaProps, 'style'>> & {
   maxRows?: number;
   minRows?: number;
   onHeightChange?: (height: number, meta: TextareaHeightChangeMeta) => void;


### PR DESCRIPTION
Make properties optional to avoid the following error:

![Screen Shot 2020-09-03 at 15 31 08](https://user-images.githubusercontent.com/8545105/92131688-9083e980-ee06-11ea-9592-1f7b120348df.png)