### PR TITLE
fix: replace useEffect with useLayoutEffect for React 17

### DIFF
--- a/.changeset/clean-kiwis-boil.md
+++ b/.changeset/clean-kiwis-boil.md
@@ -2,4 +2,4 @@
 'react-textarea-autosize': patch
 ---
 
-replace useEffect with useLayoutEffect for React 17
+Moved internal `'resize'` listener to the layout effect since React 17 calls cleanups of regular effects asynchronously. This ensures that we don't ever try to access the already unmounted ref in our listener.

--- a/.changeset/clean-kiwis-boil.md
+++ b/.changeset/clean-kiwis-boil.md
@@ -1,0 +1,5 @@
+---
+'react-textarea-autosize': patch
+---
+
+replace useEffect with useLayoutEffect for React 17

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -6,7 +6,7 @@ export { default as useComposedRef } from 'use-composed-ref';
 export const useWindowResizeListener = (listener: (event: UIEvent) => any) => {
   const latestListener = useLatest(listener);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const handler: typeof listener = (event) => {
       latestListener.current(event);
     };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,8 +92,8 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
 
   if (typeof document !== 'undefined') {
     React.useLayoutEffect(resizeTextarea);
+    useWindowResizeListener(resizeTextarea);
   }
-  useWindowResizeListener(resizeTextarea);
 
   return <textarea {...props} onChange={handleChange} ref={ref} />;
 };


### PR DESCRIPTION
`useEffect` cleanup runs since React 17 asynchronously thats why it needs to be changed

We deployed this change to a web application with quite a lot of users and could verify that the `Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.` errors were gone.

Fixes #259

cc @Andarist