### PR TITLE
Allow elements other than textarea

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ https://andarist.github.io/react-textarea-autosize/
 | `minRows`           | `number`  | Minimum number of rows to show for textarea                                                                                                                                                                                                        |
 | `onHeightChange`    | `func`    | Function invoked on textarea height change, with height as first argument. The second function argument is an object containing additional information that might be useful for custom behaviors. Current options include `{ rowHeight: number }`. |
 | `cacheMeasurements` | `boolean` | Reuse previously computed measurements when computing height of textarea. Default: `false`                                                                                                                                                         |
+| `tagName`           | `string`  | Optionally use a different tag than `textarea`. This is useful for create content editable divs. Default: `textarea`                                                                                                                               |
 
 Apart from these, the component accepts all props that are accepted by `<textarea/>`, like `style`, `onChange`, `value`, etc.
 

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -6,6 +6,14 @@ exports[`<TextareaAutosize /> renders ok 1`] = `
 </DocumentFragment>
 `;
 
+exports[`<TextareaAutosize /> renders with a div passsed for tagName 1`] = `
+<DocumentFragment>
+  <div
+    contenteditable="true"
+  />
+</DocumentFragment>
+`;
+
 exports[`<TextareaAutosize /> renders with initial height passed in style prop 1`] = `
 <DocumentFragment>
   <textarea

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -20,4 +20,11 @@ describe('<TextareaAutosize />', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('renders with a div passsed for tagName', () => {
+    const props = { tagName: 'div', contentEditable: true };
+    const { asFragment } = render(<TextareaAutosize {...props} />);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ export interface TextareaAutosizeProps extends Omit<TextareaProps, 'style'> {
   onHeightChange?: (height: number, meta: TextareaHeightChangeMeta) => void;
   cacheMeasurements?: boolean;
   style?: Style;
+  tagName?: string;
 }
 
 const TextareaAutosize: React.ForwardRefRenderFunction<
@@ -34,6 +35,7 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
     minRows,
     onChange = noop,
     onHeightChange = noop,
+    tagName = 'textarea',
     ...props
   },
   userRef: React.Ref<HTMLTextAreaElement>,
@@ -95,7 +97,11 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
     useWindowResizeListener(resizeTextarea);
   }
 
-  return <textarea {...props} onChange={handleChange} ref={ref} />;
+  return React.createElement(tagName, {
+    onChange: handleChange,
+    ref,
+    ...props,
+  });
 };
 
 export default /* #__PURE__ */ React.forwardRef(TextareaAutosize);


### PR DESCRIPTION
This is a draft of what I was thinking for allowing elements besides `textarea` to be used. Given some of the complexity around `contentEditable`, I'm not sure this is even a good idea. I wanted to put it out for comments and thoughts, but it's not ready to be merged yet.