### PR TITLE
Fix Height calculation is not accurate when using word-break

### DIFF
--- a/.changeset/quick-pianos-exercise.md
+++ b/.changeset/quick-pianos-exercise.md
@@ -2,4 +2,4 @@
 'react-textarea-autosize': patch
 ---
 
-Include word-break property when calculating the height
+Account for `word-break` property when calculating the height.

--- a/.changeset/quick-pianos-exercise.md
+++ b/.changeset/quick-pianos-exercise.md
@@ -1,0 +1,5 @@
+---
+'react-textarea-autosize': patch
+---
+
+Include word-break property when calculating the height

--- a/src/getSizingData.ts
+++ b/src/getSizingData.ts
@@ -23,6 +23,7 @@ const SIZING_STYLE = [
   'textRendering',
   'textTransform',
   'width',
+  'word-break',
 ] as const;
 
 type SizingProps = Extract<

--- a/src/getSizingData.ts
+++ b/src/getSizingData.ts
@@ -23,7 +23,7 @@ const SIZING_STYLE = [
   'textRendering',
   'textTransform',
   'width',
-  'word-break',
+  'wordBreak',
 ] as const;
 
 type SizingProps = Extract<


### PR DESCRIPTION
This fixes #325 

* Include `'wordBreak'` in sizing style