### PR TITLE
Change tab-index to tabindex.

### DIFF
--- a/.changeset/rotten-radios-travel.md
+++ b/.changeset/rotten-radios-travel.md
@@ -1,0 +1,5 @@
+---
+"react-textarea-autosize": patch
+---
+
+Fixed the `tabindex` attribute name that is set on the hidden textarea used for height calculations.

--- a/src/calculateNodeHeight.ts
+++ b/src/calculateNodeHeight.ts
@@ -28,7 +28,7 @@ export default function calculateNodeHeight(
 ): CalculatedNodeHeights {
   if (!hiddenTextarea) {
     hiddenTextarea = document.createElement('textarea');
-    hiddenTextarea.setAttribute('tab-index', '-1');
+    hiddenTextarea.setAttribute('tabindex', '-1');
     hiddenTextarea.setAttribute('aria-hidden', 'true');
     forceHiddenStyles(hiddenTextarea);
   }


### PR DESCRIPTION
The "tab-index" property does not prevent the hidden element from being keyboard accessible, it should be tabindex. See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex