### PR TITLE
Fix scrollbar on mobile issue #333

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 
 .pnp.*
 .yarn/*
+.idea
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-textarea-autosize",
+  "name": "@gry-dmitrij/react-textarea-autosize",
   "description": "textarea component for React which grows with content",
   "version": "8.5.9",
   "keywords": [
@@ -14,65 +14,65 @@
     "url": "git+https://github.com/Andarist/react-textarea-autosize.git"
   },
   "license": "MIT",
-  "main": "dist/react-textarea-autosize.cjs.js",
-  "module": "dist/react-textarea-autosize.esm.js",
+  "main": "dist/gry-dmitrij-react-textarea-autosize.cjs.js",
+  "module": "dist/gry-dmitrij-react-textarea-autosize.esm.js",
   "browser": {
-    "./dist/react-textarea-autosize.esm.js": "./dist/react-textarea-autosize.browser.esm.js"
+    "./dist/gry-dmitrij-react-textarea-autosize.esm.js": "./dist/gry-dmitrij-react-textarea-autosize.browser.esm.js"
   },
   "exports": {
     ".": {
       "types": {
-        "import": "./dist/react-textarea-autosize.cjs.mjs",
-        "default": "./dist/react-textarea-autosize.cjs.js"
+        "import": "./dist/gry-dmitrij-react-textarea-autosize.cjs.mjs",
+        "default": "./dist/gry-dmitrij-react-textarea-autosize.cjs.js"
       },
       "development": {
         "edge-light": {
-          "module": "./dist/react-textarea-autosize.development.edge-light.esm.js",
-          "import": "./dist/react-textarea-autosize.development.edge-light.cjs.mjs",
-          "default": "./dist/react-textarea-autosize.development.edge-light.cjs.js"
+          "module": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.esm.js",
+          "import": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.cjs.mjs",
+          "default": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.cjs.js"
         },
         "worker": {
-          "module": "./dist/react-textarea-autosize.development.edge-light.esm.js",
-          "import": "./dist/react-textarea-autosize.development.edge-light.cjs.mjs",
-          "default": "./dist/react-textarea-autosize.development.edge-light.cjs.js"
+          "module": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.esm.js",
+          "import": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.cjs.mjs",
+          "default": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.cjs.js"
         },
         "workerd": {
-          "module": "./dist/react-textarea-autosize.development.edge-light.esm.js",
-          "import": "./dist/react-textarea-autosize.development.edge-light.cjs.mjs",
-          "default": "./dist/react-textarea-autosize.development.edge-light.cjs.js"
+          "module": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.esm.js",
+          "import": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.cjs.mjs",
+          "default": "./dist/gry-dmitrij-react-textarea-autosize.development.edge-light.cjs.js"
         },
         "browser": {
-          "module": "./dist/react-textarea-autosize.browser.development.esm.js",
-          "import": "./dist/react-textarea-autosize.browser.development.cjs.mjs",
-          "default": "./dist/react-textarea-autosize.browser.development.cjs.js"
+          "module": "./dist/gry-dmitrij-react-textarea-autosize.browser.development.esm.js",
+          "import": "./dist/gry-dmitrij-react-textarea-autosize.browser.development.cjs.mjs",
+          "default": "./dist/gry-dmitrij-react-textarea-autosize.browser.development.cjs.js"
         },
-        "module": "./dist/react-textarea-autosize.development.esm.js",
-        "import": "./dist/react-textarea-autosize.development.cjs.mjs",
-        "default": "./dist/react-textarea-autosize.development.cjs.js"
+        "module": "./dist/gry-dmitrij-react-textarea-autosize.development.esm.js",
+        "import": "./dist/gry-dmitrij-react-textarea-autosize.development.cjs.mjs",
+        "default": "./dist/gry-dmitrij-react-textarea-autosize.development.cjs.js"
       },
       "edge-light": {
-        "module": "./dist/react-textarea-autosize.edge-light.esm.js",
-        "import": "./dist/react-textarea-autosize.edge-light.cjs.mjs",
-        "default": "./dist/react-textarea-autosize.edge-light.cjs.js"
+        "module": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.esm.js",
+        "import": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.cjs.mjs",
+        "default": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.cjs.js"
       },
       "worker": {
-        "module": "./dist/react-textarea-autosize.edge-light.esm.js",
-        "import": "./dist/react-textarea-autosize.edge-light.cjs.mjs",
-        "default": "./dist/react-textarea-autosize.edge-light.cjs.js"
+        "module": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.esm.js",
+        "import": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.cjs.mjs",
+        "default": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.cjs.js"
       },
       "workerd": {
-        "module": "./dist/react-textarea-autosize.edge-light.esm.js",
-        "import": "./dist/react-textarea-autosize.edge-light.cjs.mjs",
-        "default": "./dist/react-textarea-autosize.edge-light.cjs.js"
+        "module": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.esm.js",
+        "import": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.cjs.mjs",
+        "default": "./dist/gry-dmitrij-react-textarea-autosize.edge-light.cjs.js"
       },
       "browser": {
-        "module": "./dist/react-textarea-autosize.browser.esm.js",
-        "import": "./dist/react-textarea-autosize.browser.cjs.mjs",
-        "default": "./dist/react-textarea-autosize.browser.cjs.js"
+        "module": "./dist/gry-dmitrij-react-textarea-autosize.browser.esm.js",
+        "import": "./dist/gry-dmitrij-react-textarea-autosize.browser.cjs.mjs",
+        "default": "./dist/gry-dmitrij-react-textarea-autosize.browser.cjs.js"
       },
-      "module": "./dist/react-textarea-autosize.esm.js",
-      "import": "./dist/react-textarea-autosize.cjs.mjs",
-      "default": "./dist/react-textarea-autosize.cjs.js"
+      "module": "./dist/gry-dmitrij-react-textarea-autosize.esm.js",
+      "import": "./dist/gry-dmitrij-react-textarea-autosize.cjs.mjs",
+      "default": "./dist/gry-dmitrij-react-textarea-autosize.cjs.js"
     },
     "./package.json": "./package.json"
   },

--- a/src/calculateNodeHeight.ts
+++ b/src/calculateNodeHeight.ts
@@ -9,7 +9,7 @@ export type CalculatedNodeHeights = number[];
 let hiddenTextarea: HTMLTextAreaElement | null = null;
 
 const getHeight = (node: HTMLElement, sizingData: SizingData): number => {
-  const height = node.scrollHeight;
+  const height = node.scrollHeight + 1;
 
   if (sizingData.sizingStyle.boxSizing === 'border-box') {
     // border-box: add border, since height = content + padding + border


### PR DESCRIPTION
scrollHeight is rounded. So when scrollHeight is float scrollbar shows on the chrome mobile browser even if there is nowhere to scroll to.
I found only one way: increase the scroll by 1 px