### PR TITLE
fix: Cursor not at the end of input when using autofocus with initial…

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,7 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
     maxRows,
     minRows,
     onChange = noop,
+    onFocus = noop,
     onHeightChange = noop,
     ...props
   },
@@ -90,12 +91,28 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
     onChange(event);
   };
 
+  const handleFocus = (event: React.FocusEvent<HTMLTextAreaElement>) => {
+    if (props.autoFocus) {
+      const value = event.target.value;
+      event.target.value = '';
+      event.target.value = value;
+    }
+    onFocus(event);
+  };
+
   if (typeof document !== 'undefined') {
     React.useLayoutEffect(resizeTextarea);
     useWindowResizeListener(resizeTextarea);
   }
 
-  return <textarea {...props} onChange={handleChange} ref={ref} />;
+  return (
+    <textarea
+      {...props}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      ref={ref}
+    />
+  );
 };
 
 export default /* #__PURE__ */ React.forwardRef(TextareaAutosize);


### PR DESCRIPTION
# Description
Fixed to move the caret position to the end of the character when `autoFocus` is true at the timing of `onFocus`.

# Related Issues
#346 

# Screen Capture
|before|after|
|-----|-----|
|<img src=https://user-images.githubusercontent.com/1748326/201480137-229b5c04-8d3f-4c0f-a752-607bd14d2b65.gif>|<img src=https://user-images.githubusercontent.com/1748326/201480149-3cb22028-c391-4bf2-9d83-7ae8b8881f6a.gif>|


