### PR TITLE
Handle document.fonts not being defined (IE9)

### DIFF
--- a/.changeset/great-moose-judge.md
+++ b/.changeset/great-moose-judge.md
@@ -1,0 +1,5 @@
+---
+'react-textarea-autosize': patch
+---
+
+Clean handling of absence of document.fonts API

--- a/.changeset/great-moose-judge.md
+++ b/.changeset/great-moose-judge.md
@@ -2,4 +2,4 @@
 'react-textarea-autosize': patch
 ---
 
-Clean handling of absence of document.fonts API
+Add a guard against potentially missing `documents.fonts`

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -36,6 +36,11 @@ function useListener<
   React.useLayoutEffect(() => {
     const handler: typeof listener = (ev) => latestListener.current(ev);
 
+    // might happen if document.fonts is not defined, for instance
+    if (!target) {
+      return;
+    }
+
     target.addEventListener(type, handler);
     return () => target.removeEventListener(type, handler);
   }, []);


### PR DESCRIPTION
Sorry folks, only seeing the notifications now.

I made a simple change that should just safely handle `document.fonts` not being define.

Fixes #368