### PR TITLE
fix: Type 'CSSProperties' is not assignable to type 'Style' error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,9 +15,7 @@ type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 type Style = Omit<
   NonNullable<TextareaProps['style']>,
   'maxHeight' | 'minHeight'
-> & {
-  height?: number;
-};
+>;
 
 export type TextareaHeightChangeMeta = {
   rowHeight: number;


### PR DESCRIPTION
`react-textarea-autosize` Style type internal conflict
<img width="622" alt="image" src="https://github.com/Andarist/react-textarea-autosize/assets/30513719/26f23bcf-cc89-446b-81dd-1d7b28921d03">
and `CSSProperties` default supports `height` property, so I think we can remove union type
