### PR TITLE
Prevent display style overrides from sites

### DIFF
--- a/.changeset/two-turkeys-join.md
+++ b/.changeset/two-turkeys-join.md
@@ -1,0 +1,5 @@
+---
+'react-textarea-autosize': patch
+---
+
+Force display: block for the hidden textarea to prevent site overrides

--- a/.changeset/two-turkeys-join.md
+++ b/.changeset/two-turkeys-join.md
@@ -2,4 +2,4 @@
 'react-textarea-autosize': patch
 ---
 
-Force display: block for the hidden textarea to prevent site overrides
+Force `display: block` for the hidden textarea to prevent other styles from overriding it and thus breaking the resizing functionality

--- a/src/calculateNodeHeight.ts
+++ b/src/calculateNodeHeight.ts
@@ -26,6 +26,7 @@ export default function calculateNodeHeight(
   minRows = 1,
   maxRows = Infinity,
 ): CalculatedNodeHeights {
+  console.log('Calculating node height');
   if (!hiddenTextarea) {
     hiddenTextarea = document.createElement('textarea');
     hiddenTextarea.setAttribute('tabindex', '-1');

--- a/src/calculateNodeHeight.ts
+++ b/src/calculateNodeHeight.ts
@@ -1,5 +1,5 @@
-import { SizingData } from './getSizingData';
 import forceHiddenStyles from './forceHiddenStyles';
+import { SizingData } from './getSizingData';
 
 // TODO: use labelled tuples once they are avaiable:
 //   export type CalculatedNodeHeights = [height: number, rowHeight: number];
@@ -26,7 +26,6 @@ export default function calculateNodeHeight(
   minRows = 1,
   maxRows = Infinity,
 ): CalculatedNodeHeights {
-  console.log('Calculating node height');
   if (!hiddenTextarea) {
     hiddenTextarea = document.createElement('textarea');
     hiddenTextarea.setAttribute('tabindex', '-1');

--- a/src/forceHiddenStyles.ts
+++ b/src/forceHiddenStyles.ts
@@ -12,6 +12,7 @@ const HIDDEN_TEXTAREA_STYLE = {
 } as const;
 
 const forceHiddenStyles = (node: HTMLElement) => {
+  console.log('forceHiddenStyles');
   Object.keys(HIDDEN_TEXTAREA_STYLE).forEach((key) => {
     node.style.setProperty(
       key,

--- a/src/forceHiddenStyles.ts
+++ b/src/forceHiddenStyles.ts
@@ -8,6 +8,7 @@ const HIDDEN_TEXTAREA_STYLE = {
   'z-index': '-1000',
   top: '0',
   right: '0',
+  display: 'block',
 } as const;
 
 const forceHiddenStyles = (node: HTMLElement) => {

--- a/src/forceHiddenStyles.ts
+++ b/src/forceHiddenStyles.ts
@@ -12,7 +12,6 @@ const HIDDEN_TEXTAREA_STYLE = {
 } as const;
 
 const forceHiddenStyles = (node: HTMLElement) => {
-  console.log('forceHiddenStyles');
   Object.keys(HIDDEN_TEXTAREA_STYLE).forEach((key) => {
     node.style.setProperty(
       key,


### PR DESCRIPTION
We had an issue where our product was embedded on customer sites. One customer set the display: none for all hidden textareas. This makes sure that the hidden textarea always has the `display: block` which is required for the resizing to work.