### PR TITLE
feat: add react v19 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test:watch": "npm test -- --watch"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",


### PR DESCRIPTION
Thanks a lot for this package

I get the following warning from pnpm after upgrading to NextJS v15 (released today), which installs react 19 RC

React 19 is technically still in RC stage, but since a stable version of a major Metaframework is installing it, it's a sign that it's ready for production use and will now be used by many projects.

