### PR TITLE
Add missing sizing styles wordSpacing & scrollbarGutter

### DIFF
--- a/.changeset/serious-shoes-draw.md
+++ b/.changeset/serious-shoes-draw.md
@@ -1,0 +1,5 @@
+---
+"react-textarea-autosize": patch
+---
+
+Add missing `wordSpacing` and `scrollbarGutter` as properties that can impact sizing

--- a/src/getSizingData.ts
+++ b/src/getSizingData.ts
@@ -25,6 +25,8 @@ const SIZING_STYLE = [
   'textTransform',
   'width',
   'wordBreak',
+  'wordSpacing',
+  'scrollbarGutter',
 ] as const;
 
 type SizingProps = Extract<


### PR DESCRIPTION
Both options influence the sizing of the textarea and when you use a textarea where those two are not their initial values, sizing will be broken.