### PR TITLE
Updated use-composed-ref to 1.4.0 and use-latest to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "use-composed-ref": "^1.3.0",
-    "use-latest": "^1.2.1"
+    "use-composed-ref": "^1.4.0",
+    "use-latest": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8670,8 +8670,8 @@ __metadata:
     react-dom: ^18.2.0
     rimraf: ^3.0.2
     typescript: ^5.1.3
-    use-composed-ref: ^1.3.0
-    use-latest: ^1.2.1
+    use-composed-ref: ^1.4.0
+    use-latest: ^1.3.0
     vite: ^6.0.7
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -10048,12 +10048,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-composed-ref@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "use-composed-ref@npm:1.3.0"
+"use-composed-ref@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "use-composed-ref@npm:1.4.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: f771cbadfdc91e03b7ab9eb32d0fc0cc647755711801bf507e891ad38c4bbc5f02b2509acadf9c965ec9c5f2f642fd33bdfdfb17b0873c4ad0a9b1f5e5e724bf
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 6968fe85e7a1721e977e7bff8d98ac0975522a380aa23190fe855767bd4d91a73138225a984ddeb90448c00451fb53fa54197b922d21753cd2e2765bd47143a9
   languageName: node
   linkType: hard
 
@@ -10069,17 +10072,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-latest@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "use-latest@npm:1.2.1"
+"use-latest@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "use-latest@npm:1.3.0"
   dependencies:
     use-isomorphic-layout-effect: ^1.1.1
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: ed3f2ddddf6f21825e2ede4c2e0f0db8dcce5129802b69d1f0575fc1b42380436e8c76a6cd885d4e9aa8e292e60fb8b959c955f33c6a9123b83814a1a1875367
+  checksum: e1681ffcac542a7536adda84c022652417463eb85eac95243860cba3ae9198aa36a8b8b11eb5d85217979648ecb00fd0e2727789dd023ac00b0cc94e4f76a511
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates use-composed-ref to 1.4.0 and use-latest to 1.3.0 to get support for React 19.