### PR TITLE
fix failed to execute getComputedStyle on window

### DIFF
--- a/.changeset/odd-donuts-approve.md
+++ b/.changeset/odd-donuts-approve.md
@@ -1,0 +1,5 @@
+---
+"react-textarea-autosize": patch
+---
+
+Fixed a race condition leading to an error caused by textarea being unmounted before internal `requestAnimationFrame`'s callback being fired

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,10 +101,10 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
     React.useLayoutEffect(resizeTextarea);
     useFormResetListener(libRef, () => {
       if (!isControlled) {
-        const node = libRef.current!;
-        const currentValue = node.value;
+        const currentValue = libRef.current!.value;
         requestAnimationFrame(() => {
-          if (libRef.current && currentValue !== node.value) {
+          const node = libRef.current;
+          if (node && currentValue !== node.value) {
             resizeTextarea();
           }
         });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,7 @@ const TextareaAutosize: React.ForwardRefRenderFunction<
         const node = libRef.current!;
         const currentValue = node.value;
         requestAnimationFrame(() => {
-          if (currentValue !== node.value) {
+          if (libRef.current && currentValue !== node.value) {
             resizeTextarea();
           }
         });


### PR DESCRIPTION
Can confirm this patch solved the issue in production for us, so this is the PR replicating it.

![CleanShot 2025-03-13 at 17 09 16@2x](https://github.com/user-attachments/assets/8ea3a6a5-0ec7-4b81-8122-12572eded8b9)

Fixes https://github.com/Andarist/react-textarea-autosize/issues/411