### PR TITLE
Add a workerd target for cloudflare workers

### DIFF
--- a/.changeset/flat-areas-buy.md
+++ b/.changeset/flat-areas-buy.md
@@ -1,0 +1,7 @@
+---
+'react-textarea-autosize': patch
+---
+
+Add a workerd target for cloudflare workers
+
+This adds a patch that adds a workerd target to the build process. This lets wrangler and the cloudflare vite plugin pick up the right version of the built module, preventing issues like https://github.com/cloudflare/workers-sdk/issues/8723.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
         "default": "./dist/react-textarea-autosize.cjs.js"
       },
       "development": {
+        "workerd": {
+          "module": "./dist/react-textarea-autosize.development.workerd.esm.js",
+          "import": "./dist/react-textarea-autosize.development.workerd.cjs.mjs",
+          "default": "./dist/react-textarea-autosize.development.workerd.cjs.js"
+        },
         "worker": {
           "module": "./dist/react-textarea-autosize.development.worker.esm.js",
           "import": "./dist/react-textarea-autosize.development.worker.cjs.mjs",
@@ -39,6 +44,11 @@
         "module": "./dist/react-textarea-autosize.development.esm.js",
         "import": "./dist/react-textarea-autosize.development.cjs.mjs",
         "default": "./dist/react-textarea-autosize.development.cjs.js"
+      },
+      "workerd": {
+        "module": "./dist/react-textarea-autosize.workerd.esm.js",
+        "import": "./dist/react-textarea-autosize.workerd.cjs.mjs",
+        "default": "./dist/react-textarea-autosize.workerd.cjs.js"
       },
       "worker": {
         "module": "./dist/react-textarea-autosize.worker.esm.js",
@@ -58,6 +68,7 @@
   },
   "imports": {
     "#is-browser": {
+      "workerd": "./src/resolved-conditions/workerd.ts",
       "worker": "./src/resolved-conditions/worker.ts",
       "browser": "./src/resolved-conditions/browser.ts",
       "default": "./src/resolved-conditions/node.ts"

--- a/src/resolved-conditions/workerd.ts
+++ b/src/resolved-conditions/workerd.ts
@@ -1,0 +1,1 @@
+export const isBrowser = false;


### PR DESCRIPTION
This adds a patch that adds a workerd target to the build process. This lets wrangler and the cloudflare vite plugin pick up the right version of the built module, preventing issues like https://github.com/cloudflare/workers-sdk/issues/8723.